### PR TITLE
Feature/dialog component

### DIFF
--- a/src/Dialog/LightBoxDialog.stories.tsx
+++ b/src/Dialog/LightBoxDialog.stories.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react';
 import {Category} from '../../.storybook/util/stories-hierarchy';
-import {LightBoxDialog} from './components/dialog';
+import {LightBoxDialog} from './';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 const story: any = {
@@ -20,7 +20,7 @@ const story: any = {
 };
 const defaultProps = {};
 export const _LightBoxDialog = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(true);
   const props = {...defaultProps, open};
   return (
     <div>

--- a/src/Dialog/LightBoxDialog.stories.tsx
+++ b/src/Dialog/LightBoxDialog.stories.tsx
@@ -1,0 +1,45 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {Category} from '../../.storybook/util/stories-hierarchy';
+import {LightBoxDialog} from './components/dialog';
+import {select, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+const story: any = {
+  title: Category.SKINDS6,
+  component: LightBoxDialog,
+  decorators: [withKnobs, withA11y]
+};
+const defaultProps = {};
+export const _LightBoxDialog = () => {
+  const [open, setOpen] = React.useState(false);
+  const props = {...defaultProps, open};
+  return (
+    <div>
+      <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+        Open LightBoxDialog
+      </button>
+      <LightBoxDialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <p>
+          <a href="http://www.ebay.com">www.ebay.com</a>
+        </p>
+      </LightBoxDialog>
+    </div>
+  );
+};
+export default story;

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -1,0 +1,26 @@
+# Dialog
+
+## Dialog Usage
+
+```react
+<Dialog
+    open
+    a11yClosetext = "Close Dialog"
+    >
+        <h1>Hello World</h1>
+</Dialog>
+```
+
+## Attributes
+
+Name | Type | Stateful | Required | Description
+--- | --- | --- | --- | ---
+`open` | Boolean | Yes | No | Whether drawer is open.
+`a11yCloseText` | String | No | Yes | A11y text for close button and mask.
+
+## Events
+
+Event | Data | Description
+--- | --- | ---
+`onShow` |  | dialog opened
+`onClose` |  | dialog closed.

--- a/src/Dialog/__tests__/component.test.tsx
+++ b/src/Dialog/__tests__/component.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {mount} from 'enzyme';
+import Dialog from '..';
+
+describe('given an closed dialog', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = mount(<Dialog className="custom-class" />);
+  });
+  it('then it is hidden in the DOM', () => {
+    expect(wrapper.find('.dialog').at(0)).toHaveLength(0);
+  });
+  it('then it is visible in the DOM', () => {
+    wrapper.setProps({open: true});
+    expect(wrapper.find('.dialog').at(0)).toHaveLength(1);
+  });
+});
+describe('given a open dialog', () => {
+  let wrapper = mount(<Dialog className="custom-class" open />);
+  let component = wrapper.find('.dialog').at(0);
+  it('should render a dialog', () => {
+    expect(component).toHaveLength(1);
+  });
+  it('should render a dialog tag with .dialog', () => {
+    expect(component.hasClass('dialog')).toBe(true);
+  });
+  it('should render a dialog with custom classNames', () => {
+    expect(component.hasClass('custom-class')).toBe(true);
+  });
+  describe('when the close button is clicked', () => {
+    let spy;
+    beforeEach(() => {
+      wrapper = mount(<Dialog className="custom-class" open header={<h2>Heading</h2>} onClose={jest.fn()} />);
+    });
+    it('then it should trigger close event', () => {
+      spy = jest.spyOn(wrapper.props(), 'onClose');
+      wrapper.find('.dialog__close').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/Dialog/__tests__/component.test.tsx
+++ b/src/Dialog/__tests__/component.test.tsx
@@ -10,29 +10,29 @@
 
 import * as React from 'react';
 import {mount} from 'enzyme';
-import Dialog from '..';
+import {LightBoxDialog} from '..';
 
 describe('given an closed dialog', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = mount(<Dialog className="custom-class" />);
+    wrapper = mount(<LightBoxDialog className="custom-class" />);
   });
   it('then it is hidden in the DOM', () => {
-    expect(wrapper.find('.dialog').at(0)).toHaveLength(0);
+    expect(wrapper.find('.lightbox-dialog').at(0)).toHaveLength(0);
   });
   it('then it is visible in the DOM', () => {
     wrapper.setProps({open: true});
-    expect(wrapper.find('.dialog').at(0)).toHaveLength(1);
+    expect(wrapper.find('.lightbox-dialog').at(0)).toHaveLength(1);
   });
 });
 describe('given a open dialog', () => {
-  let wrapper = mount(<Dialog className="custom-class" open />);
-  let component = wrapper.find('.dialog').at(0);
+  let wrapper = mount(<LightBoxDialog className="custom-class" open />);
+  let component = wrapper.find('.lightbox-dialog').at(0);
   it('should render a dialog', () => {
     expect(component).toHaveLength(1);
   });
-  it('should render a dialog tag with .dialog', () => {
-    expect(component.hasClass('dialog')).toBe(true);
+  it('should render a dialog tag with .lightbox-dialog', () => {
+    expect(component.hasClass('lightbox-dialog')).toBe(true);
   });
   it('should render a dialog with custom classNames', () => {
     expect(component.hasClass('custom-class')).toBe(true);
@@ -40,11 +40,11 @@ describe('given a open dialog', () => {
   describe('when the close button is clicked', () => {
     let spy;
     beforeEach(() => {
-      wrapper = mount(<Dialog className="custom-class" open header={<h2>Heading</h2>} onClose={jest.fn()} />);
+      wrapper = mount(<LightBoxDialog className="custom-class" open header={<h2>Heading</h2>} onClose={jest.fn()} />);
     });
     it('then it should trigger close event', () => {
       spy = jest.spyOn(wrapper.props(), 'onClose');
-      wrapper.find('.dialog__close').simulate('click');
+      wrapper.find('.lightbox-dialog__close').simulate('click');
       expect(spy).toHaveBeenCalled();
     });
   });

--- a/src/Dialog/alertDialog.stories.tsx
+++ b/src/Dialog/alertDialog.stories.tsx
@@ -10,24 +10,24 @@
 
 import * as React from 'react';
 import {Category} from '../../.storybook/util/stories-hierarchy';
-import {FullScreenDialog} from './';
+import {AlertDialog} from './';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 const story: any = {
   title: Category.SKINDS6,
-  component: FullScreenDialog,
+  component: AlertDialog,
   decorators: [withKnobs, withA11y]
 };
 const defaultProps = {};
-export const _FullScreenDialog = () => {
+export const _AlertDialog = () => {
   const [open, setOpen] = React.useState(true);
   const props = {...defaultProps, open};
   return (
     <div>
       <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
-        Open FullScreenDialog
+        Open AlertDialog
       </button>
-      <FullScreenDialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
+      <AlertDialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
           magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -38,7 +38,7 @@ export const _FullScreenDialog = () => {
         <p>
           <a href="http://www.ebay.com">www.ebay.com</a>
         </p>
-      </FullScreenDialog>
+      </AlertDialog>
     </div>
   );
 };

--- a/src/Dialog/components/alert.tsx
+++ b/src/Dialog/components/alert.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import {DialogProps} from './dialog';
+import {useFocusState} from '../../skin-utils';
+import {useEffect} from 'react';
+import DialogBase from '../../DialogBase';
+
+export const AlertDialog = ({confirmText = 'OK', onClose, ...props}: DialogProps<any> & {confirmText?: string}) => {
+  const [confirmBtnRef, setConfirmBtnFocus] = useFocusState();
+  const handleCloseBtnClick = (e) => onClose && onClose(e);
+
+  useEffect(() => {
+    if (props.open) {
+      setConfirmBtnFocus();
+    }
+  }, [props.open]);
+
+  const confirmId = 'alert-dialog-confirm';
+  const mainId = 'alert-dialog-main';
+  return (
+    <DialogBase
+      {...props}
+      role="alertdialog"
+      classPrefix="lightbox-dialog"
+      ignoreEscape
+      windowType={'compact'}
+      buttonPosition={'hidden'}
+      className={classNames(props.className, 'lightbox-dialog--mask-fade')}
+      windowClass={classNames('lightbox-dialog__window--fade', props.windowClass)}
+      footer={
+        <button
+          className="btn btn--primary lightbox-dialog__confirm"
+          ref={confirmBtnRef}
+          id={confirmId}
+          aria-describedby={mainId}
+          onClick={handleCloseBtnClick}
+        >
+          {confirmText}
+        </button>
+      }
+    />
+  );
+};
+
+export default AlertDialog;

--- a/src/Dialog/components/dialog.tsx
+++ b/src/Dialog/components/dialog.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import DialogBase, {DialogBaseProps} from '../../DialogBase';
+import classNames from 'classnames';
+
+export interface DialogProps<T> extends DialogBaseProps<T> {
+  type?: 'full' | 'fill' | 'left' | 'right';
+  onClose?: any;
+}
+
+export const Dialog = ({onClose, ...props}: DialogProps<any>) => {
+  const isFull = props.type === 'full';
+  const isCenter = !props.type || props.type === 'fill';
+  const isDocked = props.type === 'left' || props.type === 'right';
+  const handleCloseBtnClick = (e) => onClose && onClose(e);
+  const handleBackgroundClick = (e) => onClose && onClose(e);
+
+  return (
+    <DialogBase
+      {...props}
+      classPrefix="dialog"
+      className={classNames(props.className, {
+        'dialog--mask-fade-slow': isDocked,
+        'dialog--no-mask': isFull,
+        'dialog--mask-fade': isCenter
+      })}
+      windowClass={classNames({
+        [`dialog__window--${props.type}`]: props.type,
+        'dialog__window--slide': isDocked || isFull,
+        'dialog__window--fade': isCenter
+      })}
+      onCloseBtnClick={handleCloseBtnClick}
+      OnBackgroundClick={handleBackgroundClick}
+    />
+  );
+};
+export default Dialog;

--- a/src/Dialog/components/dialog.tsx
+++ b/src/Dialog/components/dialog.tsx
@@ -5,49 +5,10 @@ import classNames from 'classnames';
 export interface DialogProps<T> extends DialogBaseProps<T> {
   onClose?: any;
 }
-export const Dialog = ({onClose, ...props}: DialogProps<any>) => {
+export const DialogBaseWithClose = ({onClose, ...props}: DialogProps<any>) => {
   const handleCloseBtnClick = (e) => onClose && onClose(e);
   const handleBackgroundClick = (e) => onClose && onClose(e);
-  return <DialogBase {...props} onCloseBtnClick={handleCloseBtnClick} onBackgroundClick={handleBackgroundClick} />;
+  return <DialogBase onCloseBtnClick={handleCloseBtnClick} onBackgroundClick={handleBackgroundClick} {...props} />;
 };
-export const FullScreenDialog = (props: DialogProps<any>) => {
-  return (
-    <Dialog
-      {...props}
-      classPrefix="fullscreen-dialog"
-      windowClass={classNames('fullscreen-dialog__window--slide', props.windowClass)}
-    />
-  );
-};
-export const LightBoxDialog = ({variant, ...props}: DialogProps<any> & {variant?: '_mini'}) => {
-  const isMini = variant === '_mini';
-  const buttonPosition = (isMini && 'bottom') || props.buttonPosition || 'right';
-  return (
-    <Dialog
-      {...props}
-      classPrefix="lightbox-dialog"
-      buttonPosition={buttonPosition}
-      className={classNames(props.className, 'lightbox-dialog--mask-fade')}
-      windowClass={classNames(
-        'lightbox-dialog__window--fade',
-        {'lightbox-dialog__window--mini': isMini},
-        props.windowClass
-      )}
-    />
-  );
-};
-export const PanelDialog = ({position, ...props}: DialogProps<any> & {position?: 'end'}) => {
-  return (
-    <Dialog
-      {...props}
-      classPrefix="panel-dialog"
-      className={classNames(props.className, 'panel-dialog--mask-fade-slow')}
-      windowClass={classNames(
-        'panel-dialog__window--slide',
-        {'panel-dialog__window--end': position === 'end'},
-        props.windowClass
-      )}
-    />
-  );
-};
-export default FullScreenDialog;
+
+export default DialogBaseWithClose;

--- a/src/Dialog/components/dialog.tsx
+++ b/src/Dialog/components/dialog.tsx
@@ -3,34 +3,51 @@ import DialogBase, {DialogBaseProps} from '../../DialogBase';
 import classNames from 'classnames';
 
 export interface DialogProps<T> extends DialogBaseProps<T> {
-  type?: 'full' | 'fill' | 'left' | 'right';
   onClose?: any;
 }
-
 export const Dialog = ({onClose, ...props}: DialogProps<any>) => {
-  const isFull = props.type === 'full';
-  const isCenter = !props.type || props.type === 'fill';
-  const isDocked = props.type === 'left' || props.type === 'right';
   const handleCloseBtnClick = (e) => onClose && onClose(e);
   const handleBackgroundClick = (e) => onClose && onClose(e);
-
+  return <DialogBase {...props} onCloseBtnClick={handleCloseBtnClick} onBackgroundClick={handleBackgroundClick} />;
+};
+export const FullScreenDialog = (props: DialogProps<any>) => {
   return (
-    <DialogBase
+    <Dialog
       {...props}
-      classPrefix="dialog"
-      className={classNames(props.className, {
-        'dialog--mask-fade-slow': isDocked,
-        'dialog--no-mask': isFull,
-        'dialog--mask-fade': isCenter
-      })}
-      windowClass={classNames({
-        [`dialog__window--${props.type}`]: props.type,
-        'dialog__window--slide': isDocked || isFull,
-        'dialog__window--fade': isCenter
-      })}
-      onCloseBtnClick={handleCloseBtnClick}
-      OnBackgroundClick={handleBackgroundClick}
+      classPrefix="fullscreen-dialog"
+      windowClass={classNames('fullscreen-dialog__window--slide', props.windowClass)}
     />
   );
 };
-export default Dialog;
+export const LightBoxDialog = ({variant, ...props}: DialogProps<any> & {variant?: '_mini'}) => {
+  const isMini = variant === '_mini';
+  const buttonPosition = (isMini && 'bottom') || props.buttonPosition || 'right';
+  return (
+    <Dialog
+      {...props}
+      classPrefix="lightbox-dialog"
+      buttonPosition={buttonPosition}
+      className={classNames(props.className, 'lightbox-dialog--mask-fade')}
+      windowClass={classNames(
+        'lightbox-dialog__window--fade',
+        {'lightbox-dialog__window--mini': isMini},
+        props.windowClass
+      )}
+    />
+  );
+};
+export const PanelDialog = ({position, ...props}: DialogProps<any> & {position?: 'end'}) => {
+  return (
+    <Dialog
+      {...props}
+      classPrefix="panel-dialog"
+      className={classNames(props.className, 'panel-dialog--mask-fade-slow')}
+      windowClass={classNames(
+        'panel-dialog__window--slide',
+        {'panel-dialog__window--end': position === 'end'},
+        props.windowClass
+      )}
+    />
+  );
+};
+export default FullScreenDialog;

--- a/src/Dialog/components/fullscreen.tsx
+++ b/src/Dialog/components/fullscreen.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import {DialogBaseWithClose, DialogProps} from './dialog';
+
+export const FullScreenDialog = (props: DialogProps<any>) => {
+  return (
+    <DialogBaseWithClose
+      {...props}
+      classPrefix="fullscreen-dialog"
+      windowClass={classNames('fullscreen-dialog__window--slide', props.windowClass)}
+    />
+  );
+};
+
+export default FullScreenDialog;

--- a/src/Dialog/components/lightbox.tsx
+++ b/src/Dialog/components/lightbox.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import {DialogBaseWithClose, DialogProps} from './dialog';
+
+export const LightBoxDialog = ({variant, ...props}: DialogProps<any> & {variant?: '_mini'}) => {
+  const isMini = variant === '_mini';
+  const buttonPosition = (isMini && 'bottom') || props.buttonPosition || 'right';
+  return (
+    <DialogBaseWithClose
+      {...props}
+      classPrefix="lightbox-dialog"
+      buttonPosition={buttonPosition}
+      className={classNames(props.className, 'lightbox-dialog--mask-fade')}
+      windowClass={classNames(
+        'lightbox-dialog__window--fade',
+        {'lightbox-dialog__window--mini': isMini},
+        props.windowClass
+      )}
+    />
+  );
+};
+
+export default LightBoxDialog;

--- a/src/Dialog/components/panel.tsx
+++ b/src/Dialog/components/panel.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import {DialogBaseWithClose, DialogProps} from './dialog';
+
+export const PanelDialog = ({position, ...props}: DialogProps<any> & {position?: 'end'}) => {
+  return (
+    <DialogBaseWithClose
+      {...props}
+      classPrefix="panel-dialog"
+      className={classNames(props.className, 'panel-dialog--mask-fade-slow')}
+      windowClass={classNames(
+        'panel-dialog__window--slide',
+        {'panel-dialog__window--end': position === 'end'},
+        props.windowClass
+      )}
+    />
+  );
+};
+
+export default PanelDialog;

--- a/src/Dialog/dialog.stories.tsx
+++ b/src/Dialog/dialog.stories.tsx
@@ -1,0 +1,46 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {Category} from '../../.storybook/util/stories-hierarchy';
+import Dialog from './components/dialog';
+import {select, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+const story: any = {
+  title: Category.SKINDS6,
+  component: Dialog,
+  decorators: [withKnobs, withA11y]
+};
+const defaultProps = {};
+export const _Dialog = () => {
+  const [open, setOpen] = React.useState(false);
+  const type = select('type', ['full', 'fill', 'left', 'right', undefined], undefined);
+  const props = {...defaultProps, open, type};
+  return (
+    <div>
+      <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+        Open Dialog
+      </button>
+      <Dialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <p>
+          <a href="http://www.ebay.com">www.ebay.com</a>
+        </p>
+      </Dialog>
+    </div>
+  );
+};
+export default story;

--- a/src/Dialog/fullScreenDialog.stories.tsx
+++ b/src/Dialog/fullScreenDialog.stories.tsx
@@ -1,0 +1,45 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {Category} from '../../.storybook/util/stories-hierarchy';
+import {FullScreenDialog} from './components/dialog';
+import {select, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+const story: any = {
+  title: Category.SKINDS6,
+  component: FullScreenDialog,
+  decorators: [withKnobs, withA11y]
+};
+const defaultProps = {};
+export const _FullScreenDialog = () => {
+  const [open, setOpen] = React.useState(false);
+  const props = {...defaultProps, open};
+  return (
+    <div>
+      <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+        Open FullScreenDialog
+      </button>
+      <FullScreenDialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <p>
+          <a href="http://www.ebay.com">www.ebay.com</a>
+        </p>
+      </FullScreenDialog>
+    </div>
+  );
+};
+export default story;

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -1,0 +1,3 @@
+import Dialog from './components/dialog';
+
+export default Dialog;

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -1,3 +1,3 @@
-import Dialog from './components/dialog';
-
-export default Dialog;
+import {FullScreenDialog, LightBoxDialog, PanelDialog} from './components/dialog';
+export {FullScreenDialog, LightBoxDialog, PanelDialog} from './components/dialog';
+export default FullScreenDialog;

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -1,3 +1,9 @@
-import {FullScreenDialog, LightBoxDialog, PanelDialog} from './components/dialog';
-export {FullScreenDialog, LightBoxDialog, PanelDialog} from './components/dialog';
-export default FullScreenDialog;
+import {DialogBaseWithClose} from './components/dialog';
+export {DialogBaseWithClose, DialogProps} from './components/dialog';
+
+export {FullScreenDialog} from './components/fullscreen';
+export {LightBoxDialog} from './components/lightbox';
+export {PanelDialog} from './components/panel';
+export {AlertDialog} from './components/alert';
+
+export default DialogBaseWithClose;

--- a/src/Dialog/panelDialog.stories.tsx
+++ b/src/Dialog/panelDialog.stories.tsx
@@ -10,25 +10,24 @@
 
 import * as React from 'react';
 import {Category} from '../../.storybook/util/stories-hierarchy';
-import Dialog from './components/dialog';
+import {PanelDialog} from './components/dialog';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 const story: any = {
   title: Category.SKINDS6,
-  component: Dialog,
+  component: PanelDialog,
   decorators: [withKnobs, withA11y]
 };
 const defaultProps = {};
-export const _Dialog = () => {
+export const _PanelDialog = () => {
   const [open, setOpen] = React.useState(false);
-  const type = select('type', ['full', 'fill', 'left', 'right', undefined], undefined);
-  const props = {...defaultProps, open, type};
+  const props = {...defaultProps, open};
   return (
     <div>
       <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
-        Open Dialog
+        Open PanelDialog
       </button>
-      <Dialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
+      <PanelDialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
           magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -39,7 +38,7 @@ export const _Dialog = () => {
         <p>
           <a href="http://www.ebay.com">www.ebay.com</a>
         </p>
-      </Dialog>
+      </PanelDialog>
     </div>
   );
 };

--- a/src/Dialog/panelDialog.stories.tsx
+++ b/src/Dialog/panelDialog.stories.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react';
 import {Category} from '../../.storybook/util/stories-hierarchy';
-import {PanelDialog} from './components/dialog';
+import {PanelDialog} from './';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 const story: any = {
@@ -20,7 +20,7 @@ const story: any = {
 };
 const defaultProps = {};
 export const _PanelDialog = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(true);
   const props = {...defaultProps, open};
   return (
     <div>

--- a/src/DialogBase/components/dialogBase.tsx
+++ b/src/DialogBase/components/dialogBase.tsx
@@ -105,13 +105,12 @@ export const DialogBase = ({
         <div className={`${classPrefix}__main`} onScroll={onScroll}>
           {children}
         </div>
-        {footer ||
-          (buttonPosition === 'bottom' && (
-            <div className={`${classPrefix}__footer`}>
-              {footer}
-              {buttonPosition === 'bottom' && buttonContent}
-            </div>
-          ))}
+        {footer && (buttonPosition === 'bottom' || buttonPosition === 'hidden') && (
+          <div className={`${classPrefix}__footer`}>
+            {footer}
+            {buttonPosition === 'bottom' && buttonContent}
+          </div>
+        )}
       </div>
     </Container>
   );

--- a/src/DialogBase/components/dialogBase.tsx
+++ b/src/DialogBase/components/dialogBase.tsx
@@ -16,7 +16,7 @@ import {ReactNode} from 'react';
 export interface DialogBaseProps<T> extends React.HTMLProps<T> {
   baseEl?: 'div' | 'span' | 'aside';
   open?: boolean;
-  classPrefix?: 'drawer' | 'toast' | 'dialog' | 'drawer-dialog' | 'drawer-dialog' | 'toast-dialog';
+  classPrefix?: 'toast' | 'fullscreen-dialog' | 'lightbox-dialog' | 'panel-dialog' | 'drawer-dialog' | 'toast-dialog';
   windowClass?: string;
   windowType?: string;
   header?: ReactNode;
@@ -36,7 +36,7 @@ const Container = ({baseEl, ...props}): any => React.createElement(baseEl, props
 
 export const DialogBase = ({
   baseEl = 'div',
-  classPrefix = 'drawer',
+  classPrefix = 'drawer-dialog',
   windowClass,
   windowType,
   top,

--- a/src/skin-utils.tsx
+++ b/src/skin-utils.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as ReactDOM from 'react-dom';
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import * as Skin from './skin';
 
 // @ts-ignore
@@ -117,3 +117,12 @@ export const withHideEffect = <P extends unknown>(Component: React.ComponentType
 };
 
 export const hasValue = (input) => input && input.value && input.value.length > 0;
+
+export const useFocusState: any = () => {
+  const htmlElRef = useRef(null);
+  const setFocus = () => {
+    htmlElRef.current && htmlElRef.current.focus();
+  };
+
+  return [htmlElRef, setFocus];
+};


### PR DESCRIPTION
Dialog #1082
The dialog module has also been broken up into several modules:

Fullscreen Dialog
https://github.com/eBay/ebayui-core/tree/7.0.0/src/components/ebay-fullscreen-dialog
Lightbox Dialog
https://github.com/eBay/ebayui-core/tree/7.0.0/src/components/ebay-lightbox-dialog
Panel Dialog
https://github.com/eBay/ebayui-core/tree/7.0.0/src/components/ebay-panel-dialog

These three modules complement the two other pre-existing dialogs:

Drawer Dialog
Toast Dialog
Interesting fact: Toast dialog is currently the only non-modal dialog.

Over the past several releases we have worked hard to close the gap on dialog structural differences between DS4 and DS6. In this release, all dialog header structure & layout has been consolidated under a single system (#1171). Please refer to the Skin website to view markup requirements.

The mini-lightbox dialog underwent a minor structural change. The close button was moved before the title in the DOM. This ensures a better reading order for assistive technology (#1261).