### PR TITLE
feat: adding tests for SkinSectionTitle

### DIFF
--- a/src/SectionTitle/__tests__/__snapshots__/sectionTitle-tl.test.tsx.snap
+++ b/src/SectionTitle/__tests__/__snapshots__/sectionTitle-tl.test.tsx.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Given a section title with only a title renders properly 1`] = `
+<div
+  class="section-title"
+>
+  <div
+    class="section-title__title-container"
+  >
+    <h2
+      class="section-title__title"
+    >
+      Title
+    </h2>
+    <span
+      class="section-title__subtitle"
+    />
+  </div>
+</div>
+`;
+
+exports[`Given a section with a subtitle and CTA renders properly 1`] = `
+<div
+  class="section-title"
+>
+  <div
+    class="section-title__title-container"
+  >
+    <h2
+      class="section-title__title"
+    >
+      Title
+    </h2>
+    <span
+      class="section-title__subtitle"
+    >
+      Subtitle
+    </span>
+  </div>
+  <div
+    class="section-title__cta"
+  >
+    <a
+      aria-hidden="true"
+      href="http://ebay.com"
+      tabindex="-1"
+    >
+      <span
+        class="section-title__cta-text"
+      >
+        See All
+      </span>
+      <svg
+        aria-hidden="true"
+        class="section-title__cta-icon"
+        focusable="false"
+        height="24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-arrow-right-bold"
+        />
+      </svg>
+    </a>
+  </div>
+</div>
+`;
+
+exports[`Given a section with a subtitle and CTA with no text renders properly 1`] = `
+<div
+  class="section-title"
+>
+  <div
+    class="section-title__title-container"
+  >
+    <h2
+      class="section-title__title"
+    >
+      Title
+    </h2>
+    <span
+      class="section-title__subtitle"
+    >
+      Subtitle
+    </span>
+  </div>
+  <div
+    class="section-title__cta section-title__cta--no-text"
+  >
+    <a
+      aria-hidden="true"
+      href="http://ebay.com"
+      tabindex="-1"
+    >
+      <svg
+        aria-hidden="true"
+        class="section-title__cta-icon"
+        focusable="false"
+        height="24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-arrow-right-bold"
+        />
+      </svg>
+    </a>
+  </div>
+</div>
+`;
+
+exports[`Given a section with a subtitle renders properly 1`] = `
+<div
+  class="section-title"
+>
+  <div
+    class="section-title__title-container"
+  >
+    <h2
+      class="section-title__title"
+    >
+      Title
+    </h2>
+    <span
+      class="section-title__subtitle"
+    >
+      Subtitle
+    </span>
+  </div>
+</div>
+`;

--- a/src/SectionTitle/__tests__/sectionTitle-tl.test.tsx
+++ b/src/SectionTitle/__tests__/sectionTitle-tl.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Aaron Nance
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {render, fireEvent, cleanup} from '@testing-library/react';
+import SkinSectionTitle, {SkinSectionCTA} from '../skin-section-title';
+
+const justTitle = {
+  title: 'Title'
+};
+const titleAndSubtitle = {
+  title: 'Title',
+  subtitle: 'Subtitle'
+};
+const cta = {};
+let component;
+let container;
+
+afterEach(cleanup);
+
+describe('Given a section title with only a title', () => {
+  beforeEach(async () => {
+    component = {container} = await render(<SkinSectionTitle {...justTitle} />);
+  });
+
+  it('renders properly', async () => {
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('Given a section with a subtitle', () => {
+  beforeEach(async () => {
+    component = {container} = await render(<SkinSectionTitle {...titleAndSubtitle} />);
+  });
+
+  it('renders properly', async () => {
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('Given a section with a subtitle and CTA', () => {
+  beforeEach(async () => {
+    component = {container} = await render(
+      <SkinSectionTitle {...titleAndSubtitle}>
+        <SkinSectionCTA href="http://ebay.com" title="See All" iconName="arrow-right-bold" />
+      </SkinSectionTitle>
+    );
+  });
+
+  it('renders properly', async () => {
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('Given a section with a subtitle and CTA with no text', () => {
+  beforeEach(async () => {
+    component = {container} = await render(
+      <SkinSectionTitle {...titleAndSubtitle}>
+        <SkinSectionCTA href="http://ebay.com" iconName="arrow-right-bold" />
+      </SkinSectionTitle>
+    );
+  });
+
+  it('renders properly', async () => {
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+/* Left these here to remind me these Marko cases need to be handled.
+  it('renders with title tag', async () => {
+  it('renders with info', async () => {
+  it('renders with overflow', async () => {
+  it('renders with large size', async () => {
+*/

--- a/src/SectionTitle/sectionTitle.stories.tsx
+++ b/src/SectionTitle/sectionTitle.stories.tsx
@@ -49,6 +49,14 @@ export const _SectionTitle = () => {
           <SkinSectionCTA href="#" title="See All" iconName="arrow-right-bold" />
         </SkinSectionTitle>
       </DemoComponent>
+      <br />
+      <br />
+      <br />
+      <DemoComponent>
+        <SkinSectionTitle {...props}>
+          <SkinSectionCTA href="#" iconName="arrow-right-bold" />
+        </SkinSectionTitle>
+      </DemoComponent>
     </div>
   );
 };

--- a/src/Switch/__tests__/switch_tl.test.tsx
+++ b/src/Switch/__tests__/switch_tl.test.tsx
@@ -1,6 +1,16 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Aaron Nance
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
 import {Switch} from '../index';
 import * as React from 'react';
-import {render, wait, cleanup} from '@testing-library/react';
+import {render, cleanup} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 let component;


### PR DESCRIPTION
## Description
Adding tests to the SectionTitle component

## Context
These tests will bring the test in this repo into closer parity with the tests in ebayui-core. I did change the approach used while keeping the context the same. In ebayui-core there were many assertions tied to how the HTML should be formatted. These types of tests are better handled through snapshot tests.
