### PR TITLE
Release/2.0.0 beta.3

### DIFF
--- a/src/Dialog/LightBoxDialog.stories.tsx
+++ b/src/Dialog/LightBoxDialog.stories.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react';
 import {Category} from '../../.storybook/util/stories-hierarchy';
-import {LightBoxDialog} from './components/dialog';
+import {LightBoxDialog} from './';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 const story: any = {
@@ -20,7 +20,7 @@ const story: any = {
 };
 const defaultProps = {};
 export const _LightBoxDialog = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(true);
   const props = {...defaultProps, open};
   return (
     <div>

--- a/src/Dialog/LightBoxDialog.stories.tsx
+++ b/src/Dialog/LightBoxDialog.stories.tsx
@@ -1,0 +1,45 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {Category} from '../../.storybook/util/stories-hierarchy';
+import {LightBoxDialog} from './components/dialog';
+import {select, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+const story: any = {
+  title: Category.SKINDS6,
+  component: LightBoxDialog,
+  decorators: [withKnobs, withA11y]
+};
+const defaultProps = {};
+export const _LightBoxDialog = () => {
+  const [open, setOpen] = React.useState(false);
+  const props = {...defaultProps, open};
+  return (
+    <div>
+      <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+        Open LightBoxDialog
+      </button>
+      <LightBoxDialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <p>
+          <a href="http://www.ebay.com">www.ebay.com</a>
+        </p>
+      </LightBoxDialog>
+    </div>
+  );
+};
+export default story;

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -1,0 +1,26 @@
+# Dialog
+
+## Dialog Usage
+
+```react
+<Dialog
+    open
+    a11yClosetext = "Close Dialog"
+    >
+        <h1>Hello World</h1>
+</Dialog>
+```
+
+## Attributes
+
+Name | Type | Stateful | Required | Description
+--- | --- | --- | --- | ---
+`open` | Boolean | Yes | No | Whether drawer is open.
+`a11yCloseText` | String | No | Yes | A11y text for close button and mask.
+
+## Events
+
+Event | Data | Description
+--- | --- | ---
+`onShow` |  | dialog opened
+`onClose` |  | dialog closed.

--- a/src/Dialog/__tests__/component.test.tsx
+++ b/src/Dialog/__tests__/component.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {mount} from 'enzyme';
+import Dialog from '..';
+
+describe('given an closed dialog', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = mount(<Dialog className="custom-class" />);
+  });
+  it('then it is hidden in the DOM', () => {
+    expect(wrapper.find('.dialog').at(0)).toHaveLength(0);
+  });
+  it('then it is visible in the DOM', () => {
+    wrapper.setProps({open: true});
+    expect(wrapper.find('.dialog').at(0)).toHaveLength(1);
+  });
+});
+describe('given a open dialog', () => {
+  let wrapper = mount(<Dialog className="custom-class" open />);
+  let component = wrapper.find('.dialog').at(0);
+  it('should render a dialog', () => {
+    expect(component).toHaveLength(1);
+  });
+  it('should render a dialog tag with .dialog', () => {
+    expect(component.hasClass('dialog')).toBe(true);
+  });
+  it('should render a dialog with custom classNames', () => {
+    expect(component.hasClass('custom-class')).toBe(true);
+  });
+  describe('when the close button is clicked', () => {
+    let spy;
+    beforeEach(() => {
+      wrapper = mount(<Dialog className="custom-class" open header={<h2>Heading</h2>} onClose={jest.fn()} />);
+    });
+    it('then it should trigger close event', () => {
+      spy = jest.spyOn(wrapper.props(), 'onClose');
+      wrapper.find('.dialog__close').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/Dialog/__tests__/component.test.tsx
+++ b/src/Dialog/__tests__/component.test.tsx
@@ -10,29 +10,29 @@
 
 import * as React from 'react';
 import {mount} from 'enzyme';
-import Dialog from '..';
+import {LightBoxDialog} from '..';
 
 describe('given an closed dialog', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = mount(<Dialog className="custom-class" />);
+    wrapper = mount(<LightBoxDialog className="custom-class" />);
   });
   it('then it is hidden in the DOM', () => {
-    expect(wrapper.find('.dialog').at(0)).toHaveLength(0);
+    expect(wrapper.find('.lightbox-dialog').at(0)).toHaveLength(0);
   });
   it('then it is visible in the DOM', () => {
     wrapper.setProps({open: true});
-    expect(wrapper.find('.dialog').at(0)).toHaveLength(1);
+    expect(wrapper.find('.lightbox-dialog').at(0)).toHaveLength(1);
   });
 });
 describe('given a open dialog', () => {
-  let wrapper = mount(<Dialog className="custom-class" open />);
-  let component = wrapper.find('.dialog').at(0);
+  let wrapper = mount(<LightBoxDialog className="custom-class" open />);
+  let component = wrapper.find('.lightbox-dialog').at(0);
   it('should render a dialog', () => {
     expect(component).toHaveLength(1);
   });
-  it('should render a dialog tag with .dialog', () => {
-    expect(component.hasClass('dialog')).toBe(true);
+  it('should render a dialog tag with .lightbox-dialog', () => {
+    expect(component.hasClass('lightbox-dialog')).toBe(true);
   });
   it('should render a dialog with custom classNames', () => {
     expect(component.hasClass('custom-class')).toBe(true);
@@ -40,11 +40,11 @@ describe('given a open dialog', () => {
   describe('when the close button is clicked', () => {
     let spy;
     beforeEach(() => {
-      wrapper = mount(<Dialog className="custom-class" open header={<h2>Heading</h2>} onClose={jest.fn()} />);
+      wrapper = mount(<LightBoxDialog className="custom-class" open header={<h2>Heading</h2>} onClose={jest.fn()} />);
     });
     it('then it should trigger close event', () => {
       spy = jest.spyOn(wrapper.props(), 'onClose');
-      wrapper.find('.dialog__close').simulate('click');
+      wrapper.find('.lightbox-dialog__close').simulate('click');
       expect(spy).toHaveBeenCalled();
     });
   });

--- a/src/Dialog/alertDialog.stories.tsx
+++ b/src/Dialog/alertDialog.stories.tsx
@@ -10,24 +10,24 @@
 
 import * as React from 'react';
 import {Category} from '../../.storybook/util/stories-hierarchy';
-import {FullScreenDialog} from './';
+import {AlertDialog} from './';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 const story: any = {
   title: Category.SKINDS6,
-  component: FullScreenDialog,
+  component: AlertDialog,
   decorators: [withKnobs, withA11y]
 };
 const defaultProps = {};
-export const _FullScreenDialog = () => {
+export const _AlertDialog = () => {
   const [open, setOpen] = React.useState(true);
   const props = {...defaultProps, open};
   return (
     <div>
       <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
-        Open FullScreenDialog
+        Open AlertDialog
       </button>
-      <FullScreenDialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
+      <AlertDialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
           magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -38,7 +38,7 @@ export const _FullScreenDialog = () => {
         <p>
           <a href="http://www.ebay.com">www.ebay.com</a>
         </p>
-      </FullScreenDialog>
+      </AlertDialog>
     </div>
   );
 };

--- a/src/Dialog/components/alert.tsx
+++ b/src/Dialog/components/alert.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import {DialogProps} from './dialog';
+import {useFocusState} from '../../skin-utils';
+import {useEffect} from 'react';
+import DialogBase from '../../DialogBase';
+
+export const AlertDialog = ({confirmText = 'OK', onClose, ...props}: DialogProps<any> & {confirmText?: string}) => {
+  const [confirmBtnRef, setConfirmBtnFocus] = useFocusState();
+  const handleCloseBtnClick = (e) => onClose && onClose(e);
+
+  useEffect(() => {
+    if (props.open) {
+      setConfirmBtnFocus();
+    }
+  }, [props.open]);
+
+  const confirmId = 'alert-dialog-confirm';
+  const mainId = 'alert-dialog-main';
+  return (
+    <DialogBase
+      {...props}
+      role="alertdialog"
+      classPrefix="lightbox-dialog"
+      ignoreEscape
+      windowType={'compact'}
+      buttonPosition={'hidden'}
+      className={classNames(props.className, 'lightbox-dialog--mask-fade')}
+      windowClass={classNames('lightbox-dialog__window--fade', props.windowClass)}
+      footer={
+        <button
+          className="btn btn--primary lightbox-dialog__confirm"
+          ref={confirmBtnRef}
+          id={confirmId}
+          aria-describedby={mainId}
+          onClick={handleCloseBtnClick}
+        >
+          {confirmText}
+        </button>
+      }
+    />
+  );
+};
+
+export default AlertDialog;

--- a/src/Dialog/components/dialog.tsx
+++ b/src/Dialog/components/dialog.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import DialogBase, {DialogBaseProps} from '../../DialogBase';
+import classNames from 'classnames';
+
+export interface DialogProps<T> extends DialogBaseProps<T> {
+  type?: 'full' | 'fill' | 'left' | 'right';
+  onClose?: any;
+}
+
+export const Dialog = ({onClose, ...props}: DialogProps<any>) => {
+  const isFull = props.type === 'full';
+  const isCenter = !props.type || props.type === 'fill';
+  const isDocked = props.type === 'left' || props.type === 'right';
+  const handleCloseBtnClick = (e) => onClose && onClose(e);
+  const handleBackgroundClick = (e) => onClose && onClose(e);
+
+  return (
+    <DialogBase
+      {...props}
+      classPrefix="dialog"
+      className={classNames(props.className, {
+        'dialog--mask-fade-slow': isDocked,
+        'dialog--no-mask': isFull,
+        'dialog--mask-fade': isCenter
+      })}
+      windowClass={classNames({
+        [`dialog__window--${props.type}`]: props.type,
+        'dialog__window--slide': isDocked || isFull,
+        'dialog__window--fade': isCenter
+      })}
+      onCloseBtnClick={handleCloseBtnClick}
+      OnBackgroundClick={handleBackgroundClick}
+    />
+  );
+};
+export default Dialog;

--- a/src/Dialog/components/dialog.tsx
+++ b/src/Dialog/components/dialog.tsx
@@ -5,49 +5,10 @@ import classNames from 'classnames';
 export interface DialogProps<T> extends DialogBaseProps<T> {
   onClose?: any;
 }
-export const Dialog = ({onClose, ...props}: DialogProps<any>) => {
+export const DialogBaseWithClose = ({onClose, ...props}: DialogProps<any>) => {
   const handleCloseBtnClick = (e) => onClose && onClose(e);
   const handleBackgroundClick = (e) => onClose && onClose(e);
-  return <DialogBase {...props} onCloseBtnClick={handleCloseBtnClick} onBackgroundClick={handleBackgroundClick} />;
+  return <DialogBase onCloseBtnClick={handleCloseBtnClick} onBackgroundClick={handleBackgroundClick} {...props} />;
 };
-export const FullScreenDialog = (props: DialogProps<any>) => {
-  return (
-    <Dialog
-      {...props}
-      classPrefix="fullscreen-dialog"
-      windowClass={classNames('fullscreen-dialog__window--slide', props.windowClass)}
-    />
-  );
-};
-export const LightBoxDialog = ({variant, ...props}: DialogProps<any> & {variant?: '_mini'}) => {
-  const isMini = variant === '_mini';
-  const buttonPosition = (isMini && 'bottom') || props.buttonPosition || 'right';
-  return (
-    <Dialog
-      {...props}
-      classPrefix="lightbox-dialog"
-      buttonPosition={buttonPosition}
-      className={classNames(props.className, 'lightbox-dialog--mask-fade')}
-      windowClass={classNames(
-        'lightbox-dialog__window--fade',
-        {'lightbox-dialog__window--mini': isMini},
-        props.windowClass
-      )}
-    />
-  );
-};
-export const PanelDialog = ({position, ...props}: DialogProps<any> & {position?: 'end'}) => {
-  return (
-    <Dialog
-      {...props}
-      classPrefix="panel-dialog"
-      className={classNames(props.className, 'panel-dialog--mask-fade-slow')}
-      windowClass={classNames(
-        'panel-dialog__window--slide',
-        {'panel-dialog__window--end': position === 'end'},
-        props.windowClass
-      )}
-    />
-  );
-};
-export default FullScreenDialog;
+
+export default DialogBaseWithClose;

--- a/src/Dialog/components/dialog.tsx
+++ b/src/Dialog/components/dialog.tsx
@@ -3,34 +3,51 @@ import DialogBase, {DialogBaseProps} from '../../DialogBase';
 import classNames from 'classnames';
 
 export interface DialogProps<T> extends DialogBaseProps<T> {
-  type?: 'full' | 'fill' | 'left' | 'right';
   onClose?: any;
 }
-
 export const Dialog = ({onClose, ...props}: DialogProps<any>) => {
-  const isFull = props.type === 'full';
-  const isCenter = !props.type || props.type === 'fill';
-  const isDocked = props.type === 'left' || props.type === 'right';
   const handleCloseBtnClick = (e) => onClose && onClose(e);
   const handleBackgroundClick = (e) => onClose && onClose(e);
-
+  return <DialogBase {...props} onCloseBtnClick={handleCloseBtnClick} onBackgroundClick={handleBackgroundClick} />;
+};
+export const FullScreenDialog = (props: DialogProps<any>) => {
   return (
-    <DialogBase
+    <Dialog
       {...props}
-      classPrefix="dialog"
-      className={classNames(props.className, {
-        'dialog--mask-fade-slow': isDocked,
-        'dialog--no-mask': isFull,
-        'dialog--mask-fade': isCenter
-      })}
-      windowClass={classNames({
-        [`dialog__window--${props.type}`]: props.type,
-        'dialog__window--slide': isDocked || isFull,
-        'dialog__window--fade': isCenter
-      })}
-      onCloseBtnClick={handleCloseBtnClick}
-      OnBackgroundClick={handleBackgroundClick}
+      classPrefix="fullscreen-dialog"
+      windowClass={classNames('fullscreen-dialog__window--slide', props.windowClass)}
     />
   );
 };
-export default Dialog;
+export const LightBoxDialog = ({variant, ...props}: DialogProps<any> & {variant?: '_mini'}) => {
+  const isMini = variant === '_mini';
+  const buttonPosition = (isMini && 'bottom') || props.buttonPosition || 'right';
+  return (
+    <Dialog
+      {...props}
+      classPrefix="lightbox-dialog"
+      buttonPosition={buttonPosition}
+      className={classNames(props.className, 'lightbox-dialog--mask-fade')}
+      windowClass={classNames(
+        'lightbox-dialog__window--fade',
+        {'lightbox-dialog__window--mini': isMini},
+        props.windowClass
+      )}
+    />
+  );
+};
+export const PanelDialog = ({position, ...props}: DialogProps<any> & {position?: 'end'}) => {
+  return (
+    <Dialog
+      {...props}
+      classPrefix="panel-dialog"
+      className={classNames(props.className, 'panel-dialog--mask-fade-slow')}
+      windowClass={classNames(
+        'panel-dialog__window--slide',
+        {'panel-dialog__window--end': position === 'end'},
+        props.windowClass
+      )}
+    />
+  );
+};
+export default FullScreenDialog;

--- a/src/Dialog/components/fullscreen.tsx
+++ b/src/Dialog/components/fullscreen.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import {DialogBaseWithClose, DialogProps} from './dialog';
+
+export const FullScreenDialog = (props: DialogProps<any>) => {
+  return (
+    <DialogBaseWithClose
+      {...props}
+      classPrefix="fullscreen-dialog"
+      windowClass={classNames('fullscreen-dialog__window--slide', props.windowClass)}
+    />
+  );
+};
+
+export default FullScreenDialog;

--- a/src/Dialog/components/lightbox.tsx
+++ b/src/Dialog/components/lightbox.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import {DialogBaseWithClose, DialogProps} from './dialog';
+
+export const LightBoxDialog = ({variant, ...props}: DialogProps<any> & {variant?: '_mini'}) => {
+  const isMini = variant === '_mini';
+  const buttonPosition = (isMini && 'bottom') || props.buttonPosition || 'right';
+  return (
+    <DialogBaseWithClose
+      {...props}
+      classPrefix="lightbox-dialog"
+      buttonPosition={buttonPosition}
+      className={classNames(props.className, 'lightbox-dialog--mask-fade')}
+      windowClass={classNames(
+        'lightbox-dialog__window--fade',
+        {'lightbox-dialog__window--mini': isMini},
+        props.windowClass
+      )}
+    />
+  );
+};
+
+export default LightBoxDialog;

--- a/src/Dialog/components/panel.tsx
+++ b/src/Dialog/components/panel.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import {DialogBaseWithClose, DialogProps} from './dialog';
+
+export const PanelDialog = ({position, ...props}: DialogProps<any> & {position?: 'end'}) => {
+  return (
+    <DialogBaseWithClose
+      {...props}
+      classPrefix="panel-dialog"
+      className={classNames(props.className, 'panel-dialog--mask-fade-slow')}
+      windowClass={classNames(
+        'panel-dialog__window--slide',
+        {'panel-dialog__window--end': position === 'end'},
+        props.windowClass
+      )}
+    />
+  );
+};
+
+export default PanelDialog;

--- a/src/Dialog/dialog.stories.tsx
+++ b/src/Dialog/dialog.stories.tsx
@@ -1,0 +1,46 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {Category} from '../../.storybook/util/stories-hierarchy';
+import Dialog from './components/dialog';
+import {select, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+const story: any = {
+  title: Category.SKINDS6,
+  component: Dialog,
+  decorators: [withKnobs, withA11y]
+};
+const defaultProps = {};
+export const _Dialog = () => {
+  const [open, setOpen] = React.useState(false);
+  const type = select('type', ['full', 'fill', 'left', 'right', undefined], undefined);
+  const props = {...defaultProps, open, type};
+  return (
+    <div>
+      <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+        Open Dialog
+      </button>
+      <Dialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <p>
+          <a href="http://www.ebay.com">www.ebay.com</a>
+        </p>
+      </Dialog>
+    </div>
+  );
+};
+export default story;

--- a/src/Dialog/fullScreenDialog.stories.tsx
+++ b/src/Dialog/fullScreenDialog.stories.tsx
@@ -1,0 +1,45 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {Category} from '../../.storybook/util/stories-hierarchy';
+import {FullScreenDialog} from './components/dialog';
+import {select, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+const story: any = {
+  title: Category.SKINDS6,
+  component: FullScreenDialog,
+  decorators: [withKnobs, withA11y]
+};
+const defaultProps = {};
+export const _FullScreenDialog = () => {
+  const [open, setOpen] = React.useState(false);
+  const props = {...defaultProps, open};
+  return (
+    <div>
+      <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+        Open FullScreenDialog
+      </button>
+      <FullScreenDialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <p>
+          <a href="http://www.ebay.com">www.ebay.com</a>
+        </p>
+      </FullScreenDialog>
+    </div>
+  );
+};
+export default story;

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -1,0 +1,3 @@
+import Dialog from './components/dialog';
+
+export default Dialog;

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -1,3 +1,3 @@
-import Dialog from './components/dialog';
-
-export default Dialog;
+import {FullScreenDialog, LightBoxDialog, PanelDialog} from './components/dialog';
+export {FullScreenDialog, LightBoxDialog, PanelDialog} from './components/dialog';
+export default FullScreenDialog;

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -1,3 +1,9 @@
-import {FullScreenDialog, LightBoxDialog, PanelDialog} from './components/dialog';
-export {FullScreenDialog, LightBoxDialog, PanelDialog} from './components/dialog';
-export default FullScreenDialog;
+import {DialogBaseWithClose} from './components/dialog';
+export {DialogBaseWithClose, DialogProps} from './components/dialog';
+
+export {FullScreenDialog} from './components/fullscreen';
+export {LightBoxDialog} from './components/lightbox';
+export {PanelDialog} from './components/panel';
+export {AlertDialog} from './components/alert';
+
+export default DialogBaseWithClose;

--- a/src/Dialog/panelDialog.stories.tsx
+++ b/src/Dialog/panelDialog.stories.tsx
@@ -10,25 +10,24 @@
 
 import * as React from 'react';
 import {Category} from '../../.storybook/util/stories-hierarchy';
-import Dialog from './components/dialog';
+import {PanelDialog} from './components/dialog';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 const story: any = {
   title: Category.SKINDS6,
-  component: Dialog,
+  component: PanelDialog,
   decorators: [withKnobs, withA11y]
 };
 const defaultProps = {};
-export const _Dialog = () => {
+export const _PanelDialog = () => {
   const [open, setOpen] = React.useState(false);
-  const type = select('type', ['full', 'fill', 'left', 'right', undefined], undefined);
-  const props = {...defaultProps, open, type};
+  const props = {...defaultProps, open};
   return (
     <div>
       <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
-        Open Dialog
+        Open PanelDialog
       </button>
-      <Dialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
+      <PanelDialog {...props} onClose={() => setOpen(false)} header={<h2>Heading</h2>}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
           magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -39,7 +38,7 @@ export const _Dialog = () => {
         <p>
           <a href="http://www.ebay.com">www.ebay.com</a>
         </p>
-      </Dialog>
+      </PanelDialog>
     </div>
   );
 };

--- a/src/Dialog/panelDialog.stories.tsx
+++ b/src/Dialog/panelDialog.stories.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react';
 import {Category} from '../../.storybook/util/stories-hierarchy';
-import {PanelDialog} from './components/dialog';
+import {PanelDialog} from './';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 const story: any = {
@@ -20,7 +20,7 @@ const story: any = {
 };
 const defaultProps = {};
 export const _PanelDialog = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(true);
   const props = {...defaultProps, open};
   return (
     <div>

--- a/src/DialogBase/components/dialogBase.tsx
+++ b/src/DialogBase/components/dialogBase.tsx
@@ -105,13 +105,12 @@ export const DialogBase = ({
         <div className={`${classPrefix}__main`} onScroll={onScroll}>
           {children}
         </div>
-        {footer ||
-          (buttonPosition === 'bottom' && (
-            <div className={`${classPrefix}__footer`}>
-              {footer}
-              {buttonPosition === 'bottom' && buttonContent}
-            </div>
-          ))}
+        {footer && (buttonPosition === 'bottom' || buttonPosition === 'hidden') && (
+          <div className={`${classPrefix}__footer`}>
+            {footer}
+            {buttonPosition === 'bottom' && buttonContent}
+          </div>
+        )}
       </div>
     </Container>
   );

--- a/src/DialogBase/components/dialogBase.tsx
+++ b/src/DialogBase/components/dialogBase.tsx
@@ -52,6 +52,7 @@ export const DialogBase = ({
   onBackgroundClick = () => {},
   ignoreEscape,
   closeButton,
+  isModal,
   ...props
 }: DialogBaseProps<HTMLElement>) => {
   const drawerBaseEl = React.useRef(null);
@@ -71,7 +72,7 @@ export const DialogBase = ({
     role: props.role || 'dialog',
     className: classNames(classPrefix, props.className),
     ['hidden:no-update']: (!open).toString(),
-    ['aria-live']: !props.isModal && 'polite',
+    ['aria-live']: !isModal && 'polite',
     baseEl,
     onKeyDown: (event) => {
       if (!ignoreEscape && event.key === 'Escape') {
@@ -105,13 +106,12 @@ export const DialogBase = ({
         <div className={`${classPrefix}__main`} onScroll={onScroll}>
           {children}
         </div>
-        {footer ||
-          (buttonPosition === 'bottom' && (
-            <div className={`${classPrefix}__footer`}>
-              {footer}
-              {buttonPosition === 'bottom' && buttonContent}
-            </div>
-          ))}
+        {footer || buttonPosition === 'bottom' ? (
+          <div className={`${classPrefix}__footer`}>
+            {footer}
+            {buttonPosition === 'bottom' && buttonContent}
+          </div>
+        ) : null}
       </div>
     </Container>
   );

--- a/src/DialogBase/components/dialogBase.tsx
+++ b/src/DialogBase/components/dialogBase.tsx
@@ -16,7 +16,7 @@ import {ReactNode} from 'react';
 export interface DialogBaseProps<T> extends React.HTMLProps<T> {
   baseEl?: 'div' | 'span' | 'aside';
   open?: boolean;
-  classPrefix?: 'drawer' | 'toast' | 'dialog' | 'drawer-dialog' | 'drawer-dialog' | 'toast-dialog';
+  classPrefix?: 'toast' | 'fullscreen-dialog' | 'lightbox-dialog' | 'panel-dialog' | 'drawer-dialog' | 'toast-dialog';
   windowClass?: string;
   windowType?: string;
   header?: ReactNode;
@@ -36,7 +36,7 @@ const Container = ({baseEl, ...props}): any => React.createElement(baseEl, props
 
 export const DialogBase = ({
   baseEl = 'div',
-  classPrefix = 'drawer',
+  classPrefix = 'drawer-dialog',
   windowClass,
   windowType,
   top,

--- a/src/DialogBase/index.tsx
+++ b/src/DialogBase/index.tsx
@@ -5,15 +5,19 @@ import * as ReactDOM from 'react-dom';
 import {DialogBase, DialogBaseProps} from './components/dialogBase';
 
 export const DialogBaseWithState = (props: DialogBaseProps<HTMLElement>) => {
-  const renderOverLay = () => (
-    <div>
-      <FocusLock>
-        <RemoveScroll>
-          <DialogBase {...props} />
-        </RemoveScroll>
-      </FocusLock>
-    </div>
-  );
+  const renderOverLay = () => {
+    return props.isModal ? (
+      <div>
+        <FocusLock>
+          <RemoveScroll>
+            <DialogBase {...props} />
+          </RemoveScroll>
+        </FocusLock>
+      </div>
+    ) : (
+      <DialogBase {...props} />
+    );
+  };
   return props.open ? ReactDOM.createPortal(renderOverLay(), document.body) : null;
 };
 

--- a/src/Drawer/README.md
+++ b/src/Drawer/README.md
@@ -28,7 +28,6 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`onShow` |  | drawer opened
 `onClose` |  | drawer closed. Triggered also when user drags down on handle (touch only) when dialog is not expanded
 `onExpanded` |  | drawer expanded to full page height. Event is triggered on drag up of handle (touch only), clicks, or when user scrolls in content when dialog is not expanded
 `onCollapsed` |  | drawer collapsed back to max 50%. Event is triggered on drags do

--- a/src/Notice/README.md
+++ b/src/Notice/README.md
@@ -28,4 +28,6 @@ Name | Type | Stateful | Required | Description
 `variant`  | String | No | No | "attention" (default for "page" and "inline"), "confirmation" "information", or "celebration" (page notice only).  The default for "section" type will render with grey background and no icon
 `a11yText` | String | No | Yes | adding description for the notice for a11y users
 `hidden` | Boolean | Yes | No | whether the widget is hidden or not.
-  
+`title` | String | No | Yes |
+`conent` | ReactNode | No | Yes |
+`iconName` | IconName | No | Yes |

--- a/src/Notice/components/notice.tsx
+++ b/src/Notice/components/notice.tsx
@@ -19,6 +19,7 @@ export const getClass = (type: NoticeType) => {
   const preFix = `${type || 'page'}-notice`;
   return (postFix: string = '') => `${preFix}${postFix}`;
 };
+const SectionRows = ({type, ...props}) => React.createElement(type === 'inline' ? 'span' : 'div', props);
 
 export interface NoticeProps<T> extends Skin.Role, React.HTMLProps<T> {
   title?: string;
@@ -54,21 +55,20 @@ export const Notice = ({
   const Section = (props) => React.createElement(type === 'inline' ? 'div' : 'section', props);
   const HTMLProps = {...props, className, role};
   return (
-    <Section aria-labelledby={id} {...HTMLProps}>
-      <NoticeStatus
-        id={id}
-        type={type}
-        variant={variant}
-        iconName={iconName}
-        iconProps={iconProps}
-        a11yText={a11yText}
-      />
+    <Section aria-label={a11yText || variant} {...HTMLProps}>
+      <NoticeStatus type={type} variant={variant} iconName={iconName} iconProps={iconProps} a11yText={a11yText} />
       {(content || title) && (
         <NoticeContent type={type} title={title}>
           {content}
         </NoticeContent>
       )}
-      {children}
+      {type !== 'inline' ? (
+        <SectionRows type={type} className={getVariantClass(`__footer`)}>
+          {children}
+        </SectionRows>
+      ) : (
+        children
+      )}
     </Section>
   );
 };
@@ -90,17 +90,12 @@ export const NoticeStatus = ({
   ...props
 }: NoticeStatusProps<HTMLSpanElement>) => {
   const getVariantClass = getClass(type);
-  return React.createElement(type === 'inline' ? 'span' : 'h4', {
-    ...props,
-    className: classNames(getVariantClass('__status'), props.className),
-    children: (
-      <>
-        {props.children}
-        <span className="clipped">{a11yText}</span>
-        <Icon name={iconName ? iconName : `${variant}-filled`} {...iconProps} />
-      </>
-    )
-  });
+  return (
+    <SectionRows type={type} {...props} className={classNames(getVariantClass('__header'), props.className)}>
+      {props.children}
+      <Icon name={iconName ? iconName : `${variant}-filled`} {...iconProps} aria-label={a11yText || variant} />
+    </SectionRows>
+  );
 };
 
 interface NoticeContentProps<T> extends Skin.Role, React.HTMLProps<T> {
@@ -110,13 +105,13 @@ interface NoticeContentProps<T> extends Skin.Role, React.HTMLProps<T> {
 export const NoticeContent = ({title, type, ...props}: NoticeContentProps<HTMLSpanElement>) => {
   const getVariantClass = getClass(type);
   return (
-    <span {...props} className={classNames(getVariantClass('__content'), props.className)}>
+    <SectionRows type={type} {...props} className={classNames(getVariantClass('__main'), props.className)}>
       {title && type !== 'inline' && (
         <p>
           <span className={getVariantClass('__title')}>{title}</span>
         </p>
       )}
       {props.children}
-    </span>
+    </SectionRows>
   );
 };

--- a/src/Notice/components/notice.tsx
+++ b/src/Notice/components/notice.tsx
@@ -21,13 +21,13 @@ export const getClass = (type: NoticeType) => {
 };
 const SectionRows = ({type, ...props}) => React.createElement(type === 'inline' ? 'span' : 'div', props);
 
-export interface NoticeProps<T> extends Skin.Role, React.HTMLProps<T> {
+export interface NoticeProps<T> extends Skin.Role, Omit<React.HTMLProps<T>, 'content'> {
   title?: string;
   iconName?: IconName;
   iconProps?: object;
   variant?: NoticeVariant;
   type?: NoticeType;
-  content?: any;
+  content?: React.ReactNode;
   a11yText?: string;
 }
 export const Notice = ({

--- a/src/Notice/components/windowNotice.tsx
+++ b/src/Notice/components/windowNotice.tsx
@@ -12,22 +12,24 @@ import * as React from 'react';
 import classNames from 'classnames';
 import * as Skin from '../../skin';
 import Icon, {IconName} from '../../Icon';
+import {ReactNode} from 'react';
 
 export interface WindowNoticeProps<T> extends Skin.Role, React.HTMLProps<T> {
+  title?: string;
   a11yText?: string;
-  content?: any;
+  footer?: ReactNode;
   iconName?: IconName;
   iconProps?: any;
   isFill?: boolean;
 }
 export const WindowNotice = ({
+  title,
   children,
   isFill,
   iconName,
   iconProps = {},
   a11yText,
-  content,
-  id,
+  footer,
   role = 'region',
   ...props
 }: WindowNoticeProps<HTMLElement>) => {
@@ -40,13 +42,16 @@ export const WindowNotice = ({
   );
   const HTMLProps = {...props, className, role};
   return (
-    <section aria-labelledby={id} {...HTMLProps}>
-      <h2 id={id}>
-        {iconName && <Icon name={iconName} {...iconProps} />}
-        {a11yText && <span className="window-notice__title">{a11yText}</span>}
-      </h2>
-      {content && <p className="window-notice__content">{content}</p>}
-      {children}
+    <section aria-label={a11yText} {...HTMLProps}>
+      <div className="window-notice__header">{iconName && <Icon name={iconName} {...iconProps} />}</div>
+      {(children || title) && (
+        <div className="window-notice__main">
+          {' '}
+          {title && <h2 className="window-notice__title">{title}</h2>}
+          {children}
+        </div>
+      )}
+      {footer && <div className="window-notice__footer"> {footer} </div>}
     </section>
   );
 };

--- a/src/Notice/windowNotice.stories.tsx
+++ b/src/Notice/windowNotice.stories.tsx
@@ -25,7 +25,8 @@ const story: any = {
 };
 
 const defaultProps = {
-  id: 'window-notice'
+  id: 'window-notice',
+  className: 'window-notice--screen'
 };
 export const _NoticeWindow = () => {
   const hidden = boolean('hidden', false);
@@ -36,11 +37,15 @@ export const _NoticeWindow = () => {
         title="Your first order has been placed!"
         iconName="confirmation-filled"
         id="window-notice-1"
-        content="You'll get a confirmation email soon. The rest of your items are now ready to checkout."
         hidden={hidden}
         a11yText="Window Notice"
+        footer={
+          <Button size="large" href={'#'}>
+            Continue
+          </Button>
+        }
       >
-        <Button size="large">Continue</Button>
+        <p>You'll get a confirmation email soon. The rest of your items are now ready to checkout.</p>
       </SkinWindowNotice>
     </div>
   );

--- a/src/Notice/windowNotice.stories.tsx
+++ b/src/Notice/windowNotice.stories.tsx
@@ -25,8 +25,7 @@ const story: any = {
 };
 
 const defaultProps = {
-  id: 'window-notice',
-  className: 'window-notice--screen'
+  id: 'window-notice'
 };
 export const _NoticeWindow = () => {
   const hidden = boolean('hidden', false);

--- a/src/Stepper/README.md
+++ b/src/Stepper/README.md
@@ -15,10 +15,14 @@
 
 Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
-`direction` | any | No | Yes | 
+`direction` | String | No | No | If set to 'column' will render a vertical stepper. 
 
-## Events
+## Stepper Item
 
-Event | Data | Description
---- | --- | ---
+Name | Type | Stateful | Required | Description
+--- | --- | --- | --- | ---
+`current` | Boolean | No | No | Signifies the current step in the stepper. 
+`number` | Number | No | No | The number of the step to render.
+`type` | String | No | No | Will explicitly set the visible state of the step item.
+
 

--- a/src/Stepper/README.md
+++ b/src/Stepper/README.md
@@ -1,0 +1,24 @@
+# Stepper
+
+## Stepper Usage
+
+```react
+<Stepper>
+    <StepperItem>Started</StepperItem>
+    <StepperItem>Shipped</StepperItem>
+    <StepperItem current>Transit</StepperItem>
+    <StepperItem>Delivered</StepperItem>
+</Stepper>
+```
+
+## Attributes
+
+Name | Type | Stateful | Required | Description
+--- | --- | --- | --- | ---
+`direction` | any | No | Yes | 
+
+## Events
+
+Event | Data | Description
+--- | --- | ---
+

--- a/src/Stepper/__tests__/stepper.test.tsx
+++ b/src/Stepper/__tests__/stepper.test.tsx
@@ -1,7 +1,7 @@
 /*
  * ************************************************************
  *  Copyright 2020 eBay Inc.
- *  Author/Developer: Arturo Montoya
+ *  Author/Developer: Arturo Montoya, Michael Sinnes
  *  Use of this source code is governed by an MIT-style
  *  license that can be found in the LICENSE file or at
  *  https://opensource.org/licenses/MIT.
@@ -10,11 +10,99 @@
 
 import * as React from 'react';
 import {mount} from 'enzyme';
-import Stepper from '../index';
+import Stepper, {StepperItem} from '../index';
+import Badge from '../../Badge';
 
-describe('Toast', () => {
-  it('should render a Toast with tag aside', () => {
+const getStepperItems = (stepperNode) => stepperNode.childAt(0).childAt(0);
+
+describe('Stepper', () => {
+  it('should render a Stepper', () => {
     const component = mount(<Stepper />);
     expect(component.find('.stepper__items')).toBeTruthy();
+  });
+
+  it('should render children', () => {
+    const component = mount(
+      <Stepper>
+        <StepperItem>FirstChild</StepperItem>
+      </Stepper>
+    );
+    expect(component.find(StepperItem).length).toEqual(1);
+  });
+
+  it('should render the current item in the stepper', () => {
+    const component = mount(
+      <Stepper>
+        <StepperItem current>FirstChild</StepperItem>
+      </Stepper>
+    );
+    expect(getStepperItems(component).childAt(0).prop('current')).toBe(true);
+  });
+
+  it('should render a vertical stepper if the direction prop is "column"', () => {
+    const component = mount(
+      <Stepper direction="column">
+        <StepperItem current>FirstChild</StepperItem>
+      </Stepper>
+    );
+    expect(component.childAt(0).prop('className')).toContain('stepper--vertical');
+  });
+
+  it('should set item prior to current to confirmation type and typeClass', () => {
+    const component = mount(
+      <Stepper>
+        <StepperItem>FirstChild</StepperItem>
+        <StepperItem current>SecondChild</StepperItem>
+      </Stepper>
+    );
+    expect(getStepperItems(component).childAt(0).prop('typeClass')).toEqual('confirmation');
+    expect(getStepperItems(component).childAt(0).prop('type')).toEqual('confirmation');
+  });
+
+  it('should set the current item to current typeClass', () => {
+    const component = mount(
+      <Stepper>
+        <StepperItem>FirstChild</StepperItem>
+        <StepperItem current>SecondChild</StepperItem>
+      </Stepper>
+    );
+    expect(getStepperItems(component).childAt(2).prop('typeClass')).toEqual('current');
+  });
+
+  it('should set upcoming items to upcoming typeClass', () => {
+    const component = mount(
+      <Stepper>
+        <StepperItem>FirstChild</StepperItem>
+        <StepperItem current>SecondChild</StepperItem>
+        <StepperItem>ThirdChild</StepperItem>
+      </Stepper>
+    );
+    expect(getStepperItems(component).childAt(4).prop('typeClass')).toEqual('upcoming');
+  });
+
+  it('should set upcoming items with a to confirmation typeClass and a confirmation filled icon', () => {
+    const component = mount(
+      <Stepper>
+        <StepperItem>FirstChild</StepperItem>
+        <StepperItem current>SecondChild</StepperItem>
+        <StepperItem type="confirmation">ThirdChild</StepperItem>
+      </Stepper>
+    );
+    const child = getStepperItems(component).childAt(4);
+    expect(child.prop('typeClass')).toEqual('confirmation');
+    expect(child.childAt(0).childAt(0).childAt(0).prop('name')).toEqual('confirmation-filled');
+  });
+
+  it('should render a number in the step item if a number is passed it', () => {
+    const component = mount(
+      <Stepper>
+        <StepperItem number={1} current>
+          FirstChild
+        </StepperItem>
+      </Stepper>
+    );
+    const icon = getStepperItems(component).childAt(0).childAt(0).childAt(0).childAt(0);
+    expect(icon.is(Badge)).toBe(true);
+    expect(icon.prop('value')).toEqual(1);
   });
 });

--- a/src/Stepper/__tests__/stepper.test.tsx
+++ b/src/Stepper/__tests__/stepper.test.tsx
@@ -1,0 +1,20 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {mount} from 'enzyme';
+import Stepper from '../index';
+
+describe('Toast', () => {
+  it('should render a Toast with tag aside', () => {
+    const component = mount(<Stepper />);
+    expect(component.find('.stepper__items')).toBeTruthy();
+  });
+});

--- a/src/Stepper/components/stepper.tsx
+++ b/src/Stepper/components/stepper.tsx
@@ -1,8 +1,18 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya, Michael Sinnes
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
 import * as React from 'react';
 import classNames from 'classnames';
 
 export interface StepperProps<T> extends React.HTMLProps<T> {
-  direction?: any;
+  direction?: string | 'column';
 }
 const _getType = ({type, number}) => (number ? 'default' : type);
 export const Stepper = ({direction = 'row', children, ...props}: StepperProps<any>) => {
@@ -25,7 +35,7 @@ export const Stepper = ({direction = 'row', children, ...props}: StepperProps<an
       }
     }
     return {
-      type: !type && index < currentIndex? 'confirmation': type,
+      type: !type && index < currentIndex ? 'confirmation' : type,
       current: currentIndex === index,
       typeClass,
       transition,

--- a/src/Stepper/components/stepper.tsx
+++ b/src/Stepper/components/stepper.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+export interface StepperProps<T> extends React.HTMLProps<T> {
+  direction?: any;
+}
+const _getType = ({type, number}) => (number ? 'default' : type);
+export const Stepper = ({direction = 'row', children, ...props}: StepperProps<any>) => {
+  const childrenArray = React.Children.toArray(children);
+  // @ts-ignore
+  const currentIndex = childrenArray.findIndex((item) => item.props.current);
+  const getStepClass = (stepItem, index, list) => {
+    const type = stepItem.props.type;
+    let typeClass = _getType(stepItem.props);
+    const next = list && list[index + 1];
+    const transition = next && _getType(next.props);
+
+    if (!typeClass) {
+      if (index < currentIndex) {
+        typeClass = 'confirmation';
+      } else if (index === currentIndex) {
+        typeClass = 'current';
+      } else {
+        typeClass = 'upcoming';
+      }
+    }
+    return {
+      type: !type && index < currentIndex? 'confirmation': type,
+      current: currentIndex === index,
+      typeClass,
+      transition,
+      ...stepItem.props
+    };
+  };
+  return (
+    <div {...props} className={classNames('stepper', {'stepper--vertical': direction === 'column'}, props.className)}>
+      <div className="stepper__items" role="list">
+        {React.Children.map(children, (child, index) => {
+          const stepperPostfix = index > 0 && <hr className="stepper__separator" role="presentation" />;
+          const stepProps = getStepClass(child, index, childrenArray);
+          const newChild = React.isValidElement(child) && React.cloneElement(child, {...stepProps});
+          return (
+            <>
+              {stepperPostfix}
+              {newChild}
+            </>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+export default Stepper;

--- a/src/Stepper/components/stepperItem.tsx
+++ b/src/Stepper/components/stepperItem.tsx
@@ -1,3 +1,13 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya, Michael Sinnes
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
 import * as React from 'react';
 import classNames from 'classnames';
 import Icon from '../../Icon';
@@ -21,11 +31,11 @@ export const StepperItem = ({
 }: StepperItemProps<any>) => {
   const renderIcon = () => {
     if (['attention', 'information', 'confirmation'].includes(type)) {
-      return <Icon type={`${type}-filled`} width="24" height="24"/>;
+      return <Icon name={`${type}-filled`} width="24" height="24" />;
     } else if (number) {
-      return <Badge>{number}</Badge>;
+      return <Badge value={number} />;
     }
-    return <Icon type={type || 'circle'} width="24" height="24" />;
+    return <Icon name={type || 'circle'} width="24" height="24" />;
   };
   return (
     <div

--- a/src/Stepper/components/stepperItem.tsx
+++ b/src/Stepper/components/stepperItem.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import Icon from '../../Icon';
+import Badge from '../../Badge';
+export interface StepperItemProps<T> extends React.HTMLProps<T> {
+  transition?: any;
+  type?: 'attention' | 'information' | 'confirmation' | 'circle' | string;
+  number?: number;
+  typeClass?: 'confirmation' | 'current' | 'upcoming' | 'default';
+  current?: boolean;
+}
+
+export const StepperItem = ({
+  type,
+  number,
+  children,
+  transition,
+  typeClass = 'default',
+  current,
+  ...props
+}: StepperItemProps<any>) => {
+  const renderIcon = () => {
+    if (['attention', 'information', 'confirmation'].includes(type)) {
+      return <Icon type={`${type}-filled`} width="24" height="24"/>;
+    } else if (number) {
+      return <Badge>{number}</Badge>;
+    }
+    return <Icon type={type || 'circle'} width="24" height="24" />;
+  };
+  return (
+    <div
+      aria-current={current ? 'step' : undefined}
+      role="listitem"
+      {...props}
+      className={classNames(
+        'stepper__item',
+        {[`stepper__item--${typeClass}`]: typeClass, [`stepper__item--transition-${transition}`]: transition},
+        props.className
+      )}
+    >
+      <span className="stepper__icon">{renderIcon()}</span>
+      <span className="stepper__text">{children}</span>
+    </div>
+  );
+};
+export default StepperItem;

--- a/src/Stepper/index.tsx
+++ b/src/Stepper/index.tsx
@@ -1,0 +1,4 @@
+import Stepper from './components/stepper';
+export {Stepper} from './components/stepper';
+export {StepperItem} from './components/stepperItem';
+export default Stepper;

--- a/src/Stepper/stepper.stories.tsx
+++ b/src/Stepper/stepper.stories.tsx
@@ -21,11 +21,36 @@ export const _Stepper = () => {
   const props = {...defaultProps};
   return (
     <div>
+      <h3>Standard flow horizontal</h3>
       <Stepper {...props}>
         <StepperItem>Started</StepperItem>
         <StepperItem>Shipped</StepperItem>
         <StepperItem current>Transit</StepperItem>
         <StepperItem>Delivered</StepperItem>
+      </Stepper>
+
+      <h3>Standard flow vertical/column</h3>
+      <Stepper direction="column">
+        <StepperItem>Started</StepperItem>
+        <StepperItem>Shipped</StepperItem>
+        <StepperItem current>Transit</StepperItem>
+        <StepperItem>Delivered</StepperItem>
+      </Stepper>
+
+      <h3>Step after current completed flow</h3>
+      <Stepper {...props}>
+        <StepperItem>Started</StepperItem>
+        <StepperItem current>Shipped</StepperItem>
+        <StepperItem>Transit</StepperItem>
+        <StepperItem type="confirmation">Delivered</StepperItem>
+      </Stepper>
+
+      <h3>Number stepper</h3>
+      <Stepper>
+        <StepperItem number={1} />
+        <StepperItem number={2} />
+        <StepperItem number={3} current />
+        <StepperItem number={4} />
       </Stepper>
     </div>
   );

--- a/src/Stepper/stepper.stories.tsx
+++ b/src/Stepper/stepper.stories.tsx
@@ -1,0 +1,33 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Arturo Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {Category} from '../../.storybook/util/stories-hierarchy';
+import Stepper from './';
+import {StepperItem} from './';
+const story: any = {
+  title: Category.SKINDS6,
+  component: Stepper
+};
+const defaultProps = {};
+export const _Stepper = () => {
+  const props = {...defaultProps};
+  return (
+    <div>
+      <Stepper {...props}>
+        <StepperItem>Started</StepperItem>
+        <StepperItem>Shipped</StepperItem>
+        <StepperItem current>Transit</StepperItem>
+        <StepperItem>Delivered</StepperItem>
+      </Stepper>
+    </div>
+  );
+};
+export default story;

--- a/src/Toast/README.md
+++ b/src/Toast/README.md
@@ -1,0 +1,28 @@
+# Stepper
+
+## Stepper Usage
+
+```react
+<Stepper
+    open
+    a11yClosetext = "Close Stepper"
+    >
+
+        <h1>Hello World</h1>
+
+</Stepper>
+```
+
+## Attributes
+
+Name | Type | Stateful | Required | Description
+--- | --- | --- | --- | ---
+`open` | Boolean | Yes | No | Whether drawer is open.
+`a11yCloseText` | String | No | Yes | A11y text for close button and mask.
+
+## Events
+
+Event | Data | Description
+--- | --- | ---
+`onShow` |  | drawer opened
+`onClose` |  | drawer closed

--- a/src/Toast/README.md
+++ b/src/Toast/README.md
@@ -1,16 +1,16 @@
-# Stepper
+# Toast
 
-## Stepper Usage
+## Toast Usage
 
 ```react
-<Stepper
+<Toast
     open
-    a11yClosetext = "Close Stepper"
+    a11yClosetext = "Close Toast"
     >
 
         <h1>Hello World</h1>
 
-</Stepper>
+</Toast>
 ```
 
 ## Attributes

--- a/src/Toast/__tests__/toast.test.tsx
+++ b/src/Toast/__tests__/toast.test.tsx
@@ -1,0 +1,20 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Erik Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {mount} from 'enzyme';
+import Toast from '../components/toast';
+
+describe('Toast', () => {
+  it('should render a Toast with tag aside', () => {
+    const component = mount(<Toast open />);
+    expect(component.find('aside')).toBeTruthy();
+  });
+});

--- a/src/Toast/components/toast.tsx
+++ b/src/Toast/components/toast.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import DialogBase, {DialogBaseProps} from '../../DialogBase';
+import classNames from 'classnames';
+
+export interface ToastProps<T> extends DialogBaseProps<T> {
+  onClose?: any;
+}
+
+export const Toast = ({onClose, ...props}: ToastProps<any>) => {
+  const handleCloseBtnClick = (e) => onClose && onClose(e);
+  return (
+    <DialogBase
+      {...props}
+      tag="aside"
+      classPrefix="toast"
+      buttonPosition="right"
+      className={classNames(props.className, 'toast--transition')}
+      onCloseBtnClick={handleCloseBtnClick}
+    />
+  );
+};
+export default Toast;

--- a/src/Toast/components/toast.tsx
+++ b/src/Toast/components/toast.tsx
@@ -11,10 +11,11 @@ export const Toast = ({onClose, ...props}: ToastProps<any>) => {
   return (
     <DialogBase
       {...props}
-      tag="aside"
-      classPrefix="toast"
+      isModal={false}
+      baseEl="aside"
+      classPrefix="toast-dialog"
       buttonPosition="right"
-      className={classNames(props.className, 'toast--transition')}
+      className={classNames(props.className, 'toast-dialog--transition')}
       onCloseBtnClick={handleCloseBtnClick}
     />
   );

--- a/src/Toast/index.tsx
+++ b/src/Toast/index.tsx
@@ -1,0 +1,3 @@
+import Toast from './components/toast';
+
+export default Toast;

--- a/src/Toast/toast.stories.tsx
+++ b/src/Toast/toast.stories.tsx
@@ -1,0 +1,49 @@
+/*
+ * ************************************************************
+ *  Copyright 2020 eBay Inc.
+ *  Author/Developer: Erik Montoya
+ *  Use of this source code is governed by an MIT-style
+ *  license that can be found in the LICENSE file or at
+ *  https://opensource.org/licenses/MIT.
+ *  ***********************************************************
+ */
+
+import * as React from 'react';
+import {Category} from '../../.storybook/util/stories-hierarchy';
+import Toast from './components/toast';
+const story: any = {
+  title: Category.SKINDS6,
+  component: Toast
+};
+const defaultProps = {};
+export const _Toast = () => {
+  const [open, setOpen] = React.useState(false);
+  const props = {...defaultProps, open};
+  return (
+    <div>
+      <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+        Open Toast
+      </button>
+      <Toast
+        {...props}
+        header={
+          <h2 id="toast-title" className="toast__title">
+            Heading
+          </h2>
+        }
+        onClose={() => setOpen(false)}
+        footer={
+          <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+            Close
+          </button>
+        }
+      >
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
+        <p>
+          <a href="http://www.ebay.com">www.ebay.com</a>
+        </p>
+      </Toast>
+    </div>
+  );
+};
+export default story;

--- a/src/Toast/toast.stories.tsx
+++ b/src/Toast/toast.stories.tsx
@@ -15,7 +15,7 @@ const story: any = {
   title: Category.SKINDS6,
   component: Toast
 };
-const defaultProps = {};
+const defaultProps = {allyCloseText: 'Close Toast'};
 export const _Toast = () => {
   const [open, setOpen] = React.useState(false);
   const props = {...defaultProps, open};
@@ -27,14 +27,14 @@ export const _Toast = () => {
       <Toast
         {...props}
         header={
-          <h2 id="toast-title" className="toast__title">
+          <h2 id="toast-title" className="toast-dialog__title">
             Heading
           </h2>
         }
         onClose={() => setOpen(false)}
         footer={
-          <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
-            Close
+          <button accessKey="v" className="btn btn--primary toast-dialog__confirm" onClick={() => setOpen(!open)}>
+            View Account
           </button>
         }
       >

--- a/src/skin-utils.tsx
+++ b/src/skin-utils.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as ReactDOM from 'react-dom';
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import * as Skin from './skin';
 
 // @ts-ignore
@@ -117,3 +117,12 @@ export const withHideEffect = <P extends unknown>(Component: React.ComponentType
 };
 
 export const hasValue = (input) => input && input.value && input.value.length > 0;
+
+export const useFocusState: any = () => {
+  const htmlElRef = useRef(null);
+  const setFocus = () => {
+    htmlElRef.current && htmlElRef.current.focus();
+  };
+
+  return [htmlElRef, setFocus];
+};


### PR DESCRIPTION
Introduction
Skin v11 marks another significant step towards normalizing & unifying our DS4 and DS6 "skins" under a single design system language (internally referred to as "6.5").

DS6 is now rebranded as our "default" skin, and DS4 as our "legacy" skin (although we anticipate using the old and new names interchangeably for a little while longer yet).

We see the future of Skin as a token based system that can generate potentially multiple visual expressions (or skins) of the same design system language.

Breaking Changes
There are a significant amount of breaking changes in this release. Please read these notes in full before upgrading.

For detailed information, each section heading contains a link to the relevant issue or PR.

Page Background Colour #1136
The DS4 page background colour has changed from grey (#f5f5f5) to white.

We encourage all teams transitioning from the legacy design system to adopt this new background colour.

Page Font #1178
Both DS4 and DS6 have been updated to use Market Sans for titles only as per the design system language.

Arial is the new default font.

Button #1172
DS4 and DS6 buttons have been consolidated & aligned to the new design system language.

There are three types of button:

default (basic/minimal style)
primary
secondary
There are two sizes:

default (40px height)
large (48px height)
DS4 button colours have not been changed.

DS4 button width has been changed.

All buttons (including dropdown buttons) now have the same default width.

These changes, and simplifications, should hopefully result in less confusion and fewer issues pertaining to button states and styles.

If you wish to retain the old, wider style of buttons, view PR #1277 for two simple ways to opt-in.

CTA Button #1172
Red & blue color variants of CTA-Button have been removed.

Checkbox & Radio #1179
Checkbox and radio button size is no longer driven by a CSS media query - it is now instead driven by SVG icon size (e.g. #icon-checkbox-unchecked vs #icon-checkbox-unchecked-large). The large, non-default size requires a modifier class (e.g. .checkbox--large).

Notice #1150
The first module to undergo a major overhaul is "notice". We have elevated each of the existing base classes to standalone modules:

Window-Notice
Page-Notice
Section-Notice
Inline-Notice
The page-notice (https://ebay.github.io/skin/#page-notice) also underwent some structural changes (#1166). The heading element now wraps the visible text instead of the icon. Please refer to the skin documentation for markup requirements.

Tooltip #1168
Like the notice module, the tooltip base classes have also been elevated into standalone modules:

Tooltip
Infotip
Tourtip
DS4 tooltips, infotips & tourtips have been aligned with the new "decibel-level" system. This means that DS4 borders, pointers & backgrounds are now more in line with DS6.

Dialog #1082
The dialog module has also been broken up into several modules:

Fullscreen Dialog
Lightbox Dialog
Panel Dialog
These three modules complement the two other pre-existing dialogs:

Drawer Dialog
Toast Dialog
Interesting fact: Toast dialog is currently the only non-modal dialog.

Over the past several releases we have worked hard to close the gap on dialog structural differences between DS4 and DS6. In this release, all dialog header structure & layout has been consolidated under a single system (#1171). Please refer to the Skin website to view markup requirements.

The mini-lightbox dialog underwent a minor structural change. The close button was moved before the title in the DOM. This ensures a better reading order for assistive technology (#1261).

Wizard Stepper f91e1f6
In v10, the "wizard-stepper" module was renamed to just stepper. The old name, all classes, and references have now been permanently removed.

Deprecations
Expand Button #1233
Primary and secondary variants have been phased out of the new design system language and removed from our documentation.

Misc Cleanup 226dc72
Old code that was previously deprecated has been removed. A list of significant removals will be posted here. Stay tuned...

New Features
Alert & Confirm Dialogs #1176 #1175